### PR TITLE
Index the pad's last edit time instead of the indexing time

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -48,12 +48,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: plugin
-      -
-        name: Determine plugin name
-        id: plugin_name
-        working-directory: ./plugin
-        run: |
-          npx -c 'printf %s\\n "::set-output name=plugin_name::${npm_package_name}"'
       - name: Remove tests
         working-directory: ./etherpad-lite
         run: rm -rf ./src/tests/backend/specs
@@ -61,32 +55,17 @@ jobs:
         name: Install Etherpad core dependencies
         working-directory: ./etherpad-lite
         run: bin/installDeps.sh
-      - name: Link plugin directory
-        working-directory: ./plugin
-        run: |
-          pnpm link --global
       - name: Build Solr
         working-directory: ./plugin
         run: |
           docker buildx build -o type=docker -t ep_search/solr -f ./example/solr/Dockerfile ./example/solr
-      - name: Link plugin to etherpad-lite
+      - name: Install plugin
         working-directory: ./etherpad-lite
         run: |
-          pnpm link --global $PLUGIN_NAME
           pnpm run plugins i --path ../../plugin
-        env:
-          PLUGIN_NAME: ${{ steps.plugin_name.outputs.plugin_name }}
-      - name: Link ep_etherpad-lite
-        working-directory: ./etherpad-lite/src
-        run: |
-          pnpm link --global
-      - name: Link etherpad to plugin
-        working-directory: ./plugin
-        run: |
-          pnpm link --global ep_etherpad-lite
       -
         name: Run the backend tests
-        working-directory: ./etherpad-lite
+        working-directory: ./etherpad-lite/src
         run: |
           docker run -d --name etherpad-solr -p 8983:8983 ep_search/solr
           MAX_ATTEMPTS=60
@@ -110,7 +89,13 @@ jobs:
             fi
             sleep 0.5
           done
-          pnpm run test
+          shopt -s globstar
+          res=$(find ./plugin_packages -path "*/static/tests/backend/specs/*" 2>/dev/null | wc -l)
+          if [ $res -eq 0 ]; then
+            echo "No backend tests found"
+            exit 1
+          fi
+          npx cross-env NODE_ENV=production mocha --import=tsx --timeout 120000 --recursive plugin_packages/ep_*/static/tests/backend/specs/** --settings ../plugin/tests/settings.json
         env:
           LOGLEVEL: DEBUG
       - name: Stop Solr

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -23,10 +23,14 @@ jobs:
         with:
           repository: ether/etherpad-lite
           path: etherpad-lite
-      - uses: pnpm/action-setup@v3
+      - uses: actions/setup-node@v6
+        name: Install Node.js
+        with:
+          node-version: 24
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 8
+          package_json_file: ./etherpad-lite/package.json
           run_install: false
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -15,10 +15,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ether/etherpad-lite
-      - uses: pnpm/action-setup@v3
+      - uses: actions/setup-node@v6
+        name: Install Node.js
+        with:
+          node-version: 24
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 8
+          package_json_file: ./package.json
           run_install: false
       - name: Get pnpm store directory
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,7 @@ FROM etherpad/etherpad:2
 USER root
 
 COPY . /tmp/ep_search
-RUN cd /tmp/ep_search \
-    && ls -la /tmp/ep_search \
-    && npm pack
+RUN ls -la /tmp/ep_search
 
 USER etherpad
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 // Main job is to check pads periodically for activity and notify owners
 // when someone begins editing and when someone finishes.
 const db = require('ep_etherpad-lite/node/db/DB').db;
+const padManager = require('ep_etherpad-lite/node/db/PadManager');
 const { createPadSerializer, createSearchEngine } = require('./setup');
 
 // Settings -- EDIT THESE IN settings.json not here..
@@ -40,15 +41,17 @@ async function initializeAllPads() {
  * @param {*} pad Pad to be indexed.
  */
 async function initializePad(pad) {
-  const padData = await db.get(pad);
   let id = pad;
   const m = pad.match(/^pad:(.+)$/);
   if (m) {
     id = m[1];
   }
-  await searchEngine.update(padSerializer(
-    Object.assign({ id }, padData),
-  ));
+  const padObject = await padManager.getPad(id);
+  try {
+    await searchEngine.update(await padSerializer(padObject));
+  } finally {
+    padManager.unloadPad(id);
+  }
 }
 
 /**
@@ -75,7 +78,7 @@ async function updateAsync(pad) {
     console.warn(logPrefix, 'Search engine not yet initialized');
     return;
   }
-  await searchEngine.update(padSerializer(pad));
+  await searchEngine.update(await padSerializer(pad));
   await searchEngine.commit();
 }
 

--- a/search-engine/solrsearch.js
+++ b/search-engine/solrsearch.js
@@ -20,10 +20,10 @@ class SolrsearchSearchEngine {
   }
 
   getDefaultSerializer() {
-    return (pad) => {
+    return async (pad) => {
       const atext = (pad.atext || {}).text || '';
       return {
-        indexed: new Date().toISOString(),
+        indexed: new Date(await pad.getLastEdit()).toISOString(),
         id: pad.id,
         _text_: atext,
         atext,

--- a/tests/settings.json
+++ b/tests/settings.json
@@ -1,0 +1,655 @@
+/**
+ * THIS IS THE SETTINGS FILE THAT IS COPIED INSIDE THE DOCKER CONTAINER.
+ *
+ * By default, some runtime customizations are supported (see the
+ * documentation).
+ *
+ * If you need more control, edit this file and rebuild the container.
+ */
+
+/*
+ * This file must be valid JSON. But comments are allowed
+ *
+ * Please edit settings.json, not settings.json.template
+ *
+ * Please note that starting from Etherpad 1.6.0 you can store DB credentials in
+ * a separate file (credentials.json).
+ *
+ *
+ * ENVIRONMENT VARIABLE SUBSTITUTION
+ * =================================
+ *
+ * All the configuration values can be read from environment variables using the
+ * syntax "${ENV_VAR}" or "${ENV_VAR:default_value}".
+ *
+ * This is useful, for example, when running in a Docker container.
+ *
+ * DETAILED RULES:
+ *   - If the environment variable is set to the string "true" or "false", the
+ *     value becomes Boolean true or false.
+ *   - If the environment variable is set to the string "null", the value
+ *     becomes null.
+ *   - If the environment variable is set to the string "undefined", the setting
+ *     is removed entirely, except when used as the member of an array in which
+ *     case it becomes null.
+ *   - If the environment variable is set to a string representation of a finite
+ *     number, the string is converted to that number.
+ *   - If the environment variable is set to any other string, including the
+ *     empty string, the value is that string.
+ *   - If the environment variable is unset and a default value is provided, the
+ *     value is as if the environment variable was set to the provided default:
+ *       - "${UNSET_VAR:}" becomes the empty string.
+ *       - "${UNSET_VAR:foo}" becomes the string "foo".
+ *       - "${UNSET_VAR:true}" and "${UNSET_VAR:false}" become true and false.
+ *       - "${UNSET_VAR:null}" becomes null.
+ *       - "${UNSET_VAR:undefined}" causes the setting to be removed (or be set
+ *         to null, if used as a member of an array).
+ *   - If the environment variable is unset and no default value is provided,
+ *     the value becomes null. THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF
+ *     ETHERPAD; if you want the default value to be null, you should explicitly
+ *     specify "null" as the default value.
+ *
+ * EXAMPLE:
+ *    "port":     "${PORT:9001}"
+ *    "minify":   "${MINIFY}"
+ *    "skinName": "${SKIN_NAME:colibris}"
+ *
+ * Would read the configuration values for those items from the environment
+ * variables PORT, MINIFY and SKIN_NAME.
+ *
+ * If PORT and SKIN_NAME variables were not defined, the default values 9001 and
+ * "colibris" would be used.
+ * The configuration value "minify", on the other hand, does not have a
+ * designated default value. Thus, if the environment variable MINIFY were
+ * undefined, "minify" would be null.
+ *
+ * REMARKS:
+ * 1) please note that variable substitution always needs to be quoted.
+ *
+ *    "port":     9001,            <-- Literal values. When not using
+ *    "minify":   false                substitution, only strings must be
+ *    "skinName": "colibris"           quoted. Booleans and numbers must not.
+ *
+ *    "port":     "${PORT:9001}"   <-- CORRECT: if you want to use a variable
+ *    "minify":   "${MINIFY:true}"     substitution, put quotes around its name,
+ *    "skinName": "${SKIN_NAME}"       even if the required value is a number or
+ *                                     a boolean.
+ *                                     Etherpad will take care of rewriting it
+ *                                     to the proper type if necessary.
+ *
+ *    "port":     ${PORT:9001}     <-- ERROR: this is not valid json. Quotes
+ *    "minify":   ${MINIFY}            around variable names are missing.
+ *    "skinName": ${SKIN_NAME}
+ *
+ * 2) Beware of undefined variables and default values: nulls and empty strings
+ *    are different!
+ *
+ *    This is particularly important for user's passwords (see the relevant
+ *    section):
+ *
+ *    "password": "${PASSW}"  // if PASSW is not defined would result in password === null
+ *    "password": "${PASSW:}" // if PASSW is not defined would result in password === ''
+ *
+ *    If you want to use an empty value (null) as default value for a variable,
+ *    simply do not set it, without putting any colons: "${ABIWORD}".
+ *
+ * 3) if you want to use newlines in the default value of a string parameter,
+ *    use "\n" as usual.
+ *
+ *    "defaultPadText" : "${DEFAULT_PAD_TEXT}Line 1\nLine 2"
+ */
+ {
+    /*
+     * Name your instance!
+     */
+    "title": "${TITLE:Etherpad}",
+  
+    /*
+     * Pathname of the favicon you want to use. If null, the skin's favicon is
+     * used if one is provided by the skin, otherwise the default Etherpad favicon
+     * is used. If this is a relative path it is interpreted as relative to the
+     * Etherpad root directory.
+     */
+    "favicon": "${FAVICON:null}",
+  
+    /*
+     * Skin name.
+     *
+     * Its value has to be an existing directory under src/static/skins.
+     * You can write your own, or use one of the included ones:
+     *
+     * - "no-skin":  an empty skin (default). This yields the unmodified,
+     *               traditional Etherpad theme.
+     * - "colibris": the new experimental skin (since Etherpad 1.8), candidate to
+     *               become the default in Etherpad 2.0
+     */
+    "skinName": "${SKIN_NAME:colibris}",
+  
+    /*
+     * Skin Variants
+     *
+     * Use the UI skin variants builder at /p/test#skinvariantsbuilder
+     *
+     * For the colibris skin only, you can choose how to render the three main
+     * containers:
+     * - toolbar (top menu with icons)
+     * - editor (containing the text of the pad)
+     * - background (area outside of editor, mostly visible when using page style)
+     *
+     * For each of the 3 containers you can choose 4 color combinations:
+     * super-light, light, dark, super-dark.
+     *
+     * For example, to make the toolbar dark, you will include "dark-toolbar" into
+     * skinVariants.
+     *
+     * You can provide multiple skin variants separated by spaces. Default
+     * skinVariant is "super-light-toolbar super-light-editor light-background".
+     *
+     * For the editor container, you can also make it full width by adding
+     * "full-width-editor" variant (by default editor is rendered as a page, with
+     * a max-width of 900px).
+     */
+    "skinVariants": "${SKIN_VARIANTS:super-light-toolbar super-light-editor light-background}",
+  
+    /*
+     * IP and port which Etherpad should bind at.
+     *
+     * Binding to a Unix socket is also supported: just use an empty string for
+     * the ip, and put the full path to the socket in the port parameter.
+     *
+     * EXAMPLE USING UNIX SOCKET:
+     *    "ip": "",                             // <-- has to be an empty string
+     *    "port" : "/somepath/etherpad.socket", // <-- path to a Unix socket
+     */
+    "ip": "${IP:0.0.0.0}",
+    "port": "${PORT:9001}",
+  
+    /*
+     * Option to hide/show the settings.json in admin page.
+     *
+     * Default option is set to true
+     */
+    "showSettingsInAdminPage": "${SHOW_SETTINGS_IN_ADMIN_PAGE:true}",
+  
+    /*
+     * Node native SSL support
+     *
+     * This is disabled by default.
+     * Make sure to have the minimum and correct file access permissions set so
+     * that the Etherpad server can access them
+     */
+  
+    /*
+    "ssl" : {
+              "key"  : "/path-to-your/epl-server.key",
+              "cert" : "/path-to-your/epl-server.crt",
+              "ca": ["/path-to-your/epl-intermediate-cert1.crt", "/path-to-your/epl-intermediate-cert2.crt"]
+            },
+    */
+  
+    /*
+     * The type of the database.
+     *
+     * You can choose between many DB drivers, for example: dirty, postgres,
+     * sqlite, mysql.
+     *
+     * You shouldn't use "dirty" for for anything else than testing or
+     * development.
+     *
+     *
+     * Database specific settings are dependent on dbType, and go in dbSettings.
+     * Remember that since Etherpad 1.6.0 you can also store this information in
+     * credentials.json.
+     *
+     * For a complete list of the supported drivers, please refer to:
+     * https://www.npmjs.com/package/ueberdb2
+     */
+  
+    "dbType": "${DB_TYPE:dirty}",
+    "dbSettings": {
+      "host":       "${DB_HOST:undefined}",
+      "port":       "${DB_PORT:undefined}",
+      "database":   "${DB_NAME:undefined}",
+      "user":       "${DB_USER:undefined}",
+      "password":   "${DB_PASS:undefined}",
+      "charset":    "${DB_CHARSET:undefined}",
+      "filename":   "${DB_FILENAME:var/dirty.db}",
+      "collection": "${DB_COLLECTION:undefined}",
+      "url":        "${DB_URL:undefined}"
+    },
+  
+    /*
+     * The default text of a pad
+     */
+    "defaultPadText" : "${DEFAULT_PAD_TEXT:Welcome to Etherpad!\n\nThis pad text is synchronized as you type, so that everyone viewing this page sees the same text. This allows you to collaborate seamlessly on documents!\n\nGet involved with Etherpad at https:\/\/etherpad.org\n}",
+  
+    /*
+     * Default Pad behavior.
+     *
+     * Change them if you want to override.
+     */
+    "padOptions": {
+      "noColors":         "${PAD_OPTIONS_NO_COLORS:false}",
+      "showControls":     "${PAD_OPTIONS_SHOW_CONTROLS:true}",
+      "showChat":         "${PAD_OPTIONS_SHOW_CHAT:true}",
+      "showLineNumbers":  "${PAD_OPTIONS_SHOW_LINE_NUMBERS:true}",
+      "useMonospaceFont": "${PAD_OPTIONS_USE_MONOSPACE_FONT:false}",
+      "userName":         "${PAD_OPTIONS_USER_NAME:null}",
+      "userColor":        "${PAD_OPTIONS_USER_COLOR:null}",
+      "rtl":              "${PAD_OPTIONS_RTL:false}",
+      "alwaysShowChat":   "${PAD_OPTIONS_ALWAYS_SHOW_CHAT:false}",
+      "chatAndUsers":     "${PAD_OPTIONS_CHAT_AND_USERS:false}",
+      "lang":             "${PAD_OPTIONS_LANG:null}"
+    },
+  
+    /*
+     * Pad Shortcut Keys
+     */
+    "padShortcutEnabled" : {
+      "altF9":     "${PAD_SHORTCUTS_ENABLED_ALT_F9:true}",      /* focus on the File Menu and/or editbar */
+      "altC":      "${PAD_SHORTCUTS_ENABLED_ALT_C:true}",       /* focus on the Chat window */
+      "cmdShift2": "${PAD_SHORTCUTS_ENABLED_CMD_SHIFT_2:true}", /* shows a gritter popup showing a line author */
+      "delete":    "${PAD_SHORTCUTS_ENABLED_DELETE:true}",
+      "return":    "${PAD_SHORTCUTS_ENABLED_RETURN:true}",
+      "esc":       "${PAD_SHORTCUTS_ENABLED_ESC:true}",         /* in mozilla versions 14-19 avoid reconnecting pad */
+      "cmdS":      "${PAD_SHORTCUTS_ENABLED_CMD_S:true}",       /* save a revision */
+      "tab":       "${PAD_SHORTCUTS_ENABLED_TAB:true}",         /* indent */
+      "cmdZ":      "${PAD_SHORTCUTS_ENABLED_CMD_Z:true}",       /* undo/redo */
+      "cmdY":      "${PAD_SHORTCUTS_ENABLED_CMD_Y:true}",       /* redo */
+      "cmdI":      "${PAD_SHORTCUTS_ENABLED_CMD_I:true}",       /* italic */
+      "cmdB":      "${PAD_SHORTCUTS_ENABLED_CMD_B:true}",       /* bold */
+      "cmdU":      "${PAD_SHORTCUTS_ENABLED_CMD_U:true}",       /* underline */
+      "cmd5":      "${PAD_SHORTCUTS_ENABLED_CMD_5:true}",       /* strike through */
+      "cmdShiftL": "${PAD_SHORTCUTS_ENABLED_CMD_SHIFT_L:true}", /* unordered list */
+      "cmdShiftN": "${PAD_SHORTCUTS_ENABLED_CMD_SHIFT_N:true}", /* ordered list */
+      "cmdShift1": "${PAD_SHORTCUTS_ENABLED_CMD_SHIFT_1:true}", /* ordered list */
+      "cmdH":      "${PAD_SHORTCUTS_ENABLED_CMD_H:true}",       /* backspace */
+      "ctrlHome":  "${PAD_SHORTCUTS_ENABLED_CTRL_HOME:true}",   /* scroll to top of pad */
+      "pageUp":    "${PAD_SHORTCUTS_ENABLED_PAGE_UP:true}",
+      "pageDown":  "${PAD_SHORTCUTS_ENABLED_PAGE_DOWN:true}"
+    },
+  
+    /*
+     * Should we suppress errors from being visible in the default Pad Text?
+     */
+    "suppressErrorsInPadText": "${SUPPRESS_ERRORS_IN_PAD_TEXT:false}",
+  
+    /*
+     * If this option is enabled, a user must have a session to access pads.
+     * This effectively allows only group pads to be accessed.
+     */
+    "requireSession": "${REQUIRE_SESSION:false}",
+  
+    /*
+     * Users may edit pads but not create new ones.
+     *
+     * Pad creation is only via the API.
+     * This applies both to group pads and regular pads.
+     */
+    "editOnly": "${EDIT_ONLY:false}",
+  
+    /*
+     * If true, all css & js will be minified before sending to the client.
+     *
+     * This will improve the loading performance massively, but makes it difficult
+     * to debug the javascript/css
+     */
+    "minify": "${MINIFY:true}",
+  
+    /*
+     * How long may clients use served javascript code (in seconds)?
+     *
+     * Not setting this may cause problems during deployment.
+     * Set to 0 to disable caching.
+     */
+    "maxAge": "${MAX_AGE:21600}", // 60 * 60 * 6 = 6 hours
+  
+    /*
+     * Absolute path to the Abiword executable.
+     *
+     * Abiword is needed to get advanced import/export features of pads. Setting
+     * it to null disables Abiword and will only allow plain text and HTML
+     * import/exports.
+     */
+    "abiword": "${ABIWORD:null}",
+  
+    /*
+     * This is the absolute path to the soffice executable.
+     *
+     * LibreOffice can be used in lieu of Abiword to export pads.
+     * Setting it to null disables LibreOffice exporting.
+     */
+    "soffice": "${SOFFICE:null}",
+  
+    /*
+     * Allow import of file types other than the supported ones:
+     * txt, doc, docx, rtf, odt, html & htm
+     */
+    "allowUnknownFileEnds": "${ALLOW_UNKNOWN_FILE_ENDS:true}",
+  
+    /*
+     * This setting is used if you require authentication of all users.
+     *
+     * Note: "/admin" always requires authentication.
+     */
+    "requireAuthentication": "${REQUIRE_AUTHENTICATION:false}",
+  
+    /*
+     * Require authorization by a module, or a user with is_admin set, see below.
+     */
+    "requireAuthorization": "${REQUIRE_AUTHORIZATION:false}",
+  
+    /*
+     * When you use NGINX or another proxy/load-balancer set this to true.
+     *
+     * This is especially necessary when the reverse proxy performs SSL
+     * termination, otherwise the cookies will not have the "secure" flag.
+     *
+     * The other effect will be that the logs will contain the real client's IP,
+     * instead of the reverse proxy's IP.
+     */
+    "trustProxy": "${TRUST_PROXY:false}",
+  
+    /*
+     * Settings controlling the session cookie issued by Etherpad.
+     */
+    "cookie": {
+      /*
+       * How often (in milliseconds) the key used to sign the express_sid cookie
+       * should be rotated. Long rotation intervals reduce signature verification
+       * overhead (because there are fewer historical keys to check) and database
+       * load (fewer historical keys to store, and less frequent queries to
+       * get/update the keys). Short rotation intervals are slightly more secure.
+       *
+       * Multiple Etherpad processes sharing the same database (table) is
+       * supported as long as the clock sync error is significantly less than this
+       * value.
+       *
+       * Key rotation can be disabled (not recommended) by setting this to 0 or
+       * null, or by disabling session expiration (see sessionLifetime).
+       */
+      // 86400000 = 1d * 24h/d * 60m/h * 60s/m * 1000ms/s
+      "keyRotationInterval": "${COOKIE_KEY_ROTATION_INTERVAL:86400000}",
+  
+      /*
+       * Value of the SameSite cookie property. "Lax" is recommended unless
+       * Etherpad will be embedded in an iframe from another site, in which case
+       * this must be set to "None". Note: "None" will not work (the browser will
+       * not send the cookie to Etherpad) unless https is used to access Etherpad
+       * (either directly or via a reverse proxy with "trustProxy" set to true).
+       *
+       * "Strict" is not recommended because it has few security benefits but
+       * significant usability drawbacks vs. "Lax". See
+       * https://stackoverflow.com/q/41841880 for discussion.
+       */
+      "sameSite": "${COOKIE_SAME_SITE:Lax}",
+  
+      /*
+       * How long (in milliseconds) after navigating away from Etherpad before the
+       * user is required to log in again. (The express_sid cookie is set to
+       * expire at time now + sessionLifetime when first created, and its
+       * expiration time is periodically refreshed to a new now + sessionLifetime
+       * value.) If requireAuthentication is false then this value does not really
+       * matter.
+       *
+       * The "best" value depends on your users' usage patterns and the amount of
+       * convenience you desire. A long lifetime is more convenient (users won't
+       * have to log back in as often) but has some drawbacks:
+       *   - It increases the amount of state kept in the database.
+       *   - It might weaken security somewhat: The cookie expiration is refreshed
+       *     indefinitely without consulting authentication or authorization
+       *     hooks, so once a user has accessed a pad, the user can continue to
+       *     use the pad until the user leaves for longer than sessionLifetime.
+       *   - More historical keys (sessionLifetime / keyRotationInterval) must be
+       *     checked when verifying signatures.
+       *
+       * Session lifetime can be set to infinity (not recommended) by setting this
+       * to null or 0. Note that if the session does not expire, most browsers
+       * will delete the cookie when the browser exits, but a session record is
+       * kept in the database forever.
+       */
+      // 864000000 = 10d * 24h/d * 60m/h * 60s/m * 1000ms/s
+      "sessionLifetime": "${COOKIE_SESSION_LIFETIME:864000000}",
+  
+      /*
+       * How long (in milliseconds) before the expiration time of an active user's
+       * session is refreshed (to now + sessionLifetime). This setting affects the
+       * following:
+       *   - How often a new session expiration time will be written to the
+       *     database.
+       *   - How often each user's browser will ping the Etherpad server to
+       *     refresh the expiration time of the session cookie.
+       *
+       * High values reduce the load on the database and the load from browsers,
+       * but can shorten the effective session lifetime if Etherpad is restarted
+       * or the user navigates away.
+       *
+       * Automatic session refreshes can be disabled (not recommended) by setting
+       * this to null.
+       */
+      // 86400000 = 1d * 24h/d * 60m/h * 60s/m * 1000ms/s
+      "sessionRefreshInterval": "${COOKIE_SESSION_REFRESH_INTERVAL:86400000}"
+    },
+  
+    /*
+     * Privacy: disable IP logging
+     */
+    "disableIPlogging": "${DISABLE_IP_LOGGING:false}",
+  
+    /*
+     * Time (in seconds) to automatically reconnect pad when a "Force reconnect"
+     * message is shown to user.
+     *
+     * Set to 0 to disable automatic reconnection.
+     */
+    "automaticReconnectionTimeout": "${AUTOMATIC_RECONNECTION_TIMEOUT:0}",
+  
+    /*
+     * By default, when caret is moved out of viewport, it scrolls the minimum
+     * height needed to make this line visible.
+     */
+    "scrollWhenFocusLineIsOutOfViewport": {
+  
+      /*
+       * Percentage of viewport height to be additionally scrolled.
+       *
+       * E.g.: use "percentage.editionAboveViewport": 0.5, to place caret line in
+       *       the middle of viewport, when user edits a line above of the
+       *       viewport
+       *
+       * Set to 0 to disable extra scrolling
+       */
+      "percentage": {
+        "editionAboveViewport": "${FOCUS_LINE_PERCENTAGE_ABOVE:0}",
+        "editionBelowViewport": "${FOCUS_LINE_PERCENTAGE_BELOW:0}"
+      },
+  
+      /*
+       * Time (in milliseconds) used to animate the scroll transition.
+       * Set to 0 to disable animation
+       */
+      "duration": "${FOCUS_LINE_DURATION:0}",
+  
+      /*
+       * Flag to control if it should scroll when user places the caret in the
+       * last line of the viewport
+       */
+      "scrollWhenCaretIsInTheLastLineOfViewport": "${FOCUS_LINE_CARET_SCROLL:false}",
+  
+      /*
+       * Percentage of viewport height to be additionally scrolled when user
+       * presses arrow up in the line of the top of the viewport.
+       *
+       * Set to 0 to let the scroll to be handled as default by Etherpad
+       */
+      "percentageToScrollWhenUserPressesArrowUp": "${FOCUS_LINE_PERCENTAGE_ARROW_UP:0}"
+    },
+  
+    /*
+     * User accounts. These accounts are used by:
+     *   - default HTTP basic authentication if no plugin handles authentication
+     *   - some but not all authentication plugins
+     *   - some but not all authorization plugins
+     *
+     * User properties:
+     *   - password: The user's password. Some authentication plugins will ignore
+     *     this.
+     *   - is_admin: true gives access to /admin. Defaults to false. If you do not
+     *     uncomment this, /admin will not be available!
+     *   - readOnly: If true, this user will not be able to create new pads or
+     *     modify existing pads. Defaults to false.
+     *   - canCreate: If this is true and readOnly is false, this user can create
+     *     new pads. Defaults to true.
+     *
+     * Authentication and authorization plugins may define additional properties.
+     *
+     * WARNING: passwords should not be stored in plaintext in this file.
+     *          If you want to mitigate this, please install ep_hash_auth and
+     *          follow the section "secure your installation" in README.md
+     */
+  
+    "users": {
+      "admin": {
+        // 1) "password" can be replaced with "hash" if you install ep_hash_auth
+        // 2) please note that if password is null, the user will not be created
+        "password": "${ADMIN_PASSWORD:null}",
+        "is_admin": true
+      },
+      "user": {
+        // 1) "password" can be replaced with "hash" if you install ep_hash_auth
+        // 2) please note that if password is null, the user will not be created
+        "password": "${USER_PASSWORD:null}",
+        "is_admin": false
+      }
+    },
+  
+    /*
+     * Restrict socket.io transport methods
+     */
+    "socketTransportProtocols" : ["websocket", "polling"],
+  
+    "socketIo": {
+      /*
+       * Maximum permitted client message size (in bytes). All messages from
+       * clients that are larger than this will be rejected. Large values make it
+       * possible to paste large amounts of text, and plugins may require a larger
+       * value to work properly, but increasing the value increases susceptibility
+       * to denial of service attacks (malicious clients can exhaust memory).
+       */
+      "maxHttpBufferSize": "${SOCKETIO_MAX_HTTP_BUFFER_SIZE:10000}"
+    },
+  
+    /*
+     * Allow Load Testing tools to hit the Etherpad Instance.
+     *
+     * WARNING: this will disable security on the instance.
+     */
+    "loadTest": "${LOAD_TEST:false}",
+  
+    /**
+    * Disable dump of objects preventing a clean exit
+    */
+    "dumpOnUncleanExit": "${DUMP_ON_UNCLEAN_EXIT:false}",
+  
+    /*
+     * Disable indentation on new line when previous line ends with some special
+     * chars (':', '[', '(', '{')
+     */
+  
+    /*
+    "indentationOnNewLine": false,
+    */
+  
+    /*
+     * From Etherpad 1.8.3 onwards, import and export of pads is always rate
+     * limited.
+     *
+     * The default is to allow at most 10 requests per IP in a 90 seconds window.
+     * After that the import/export request is rejected.
+     *
+     * See https://github.com/nfriedly/express-rate-limit for more options
+     */
+    "importExportRateLimiting": {
+      // duration of the rate limit window (milliseconds)
+      "windowMs": "${IMPORT_EXPORT_RATE_LIMIT_WINDOW:90000}",
+  
+      // maximum number of requests per IP to allow during the rate limit window
+      "max": "${IMPORT_EXPORT_MAX_REQ_PER_IP:10}"
+    },
+  
+    /*
+     * From Etherpad 1.8.3 onwards, the maximum allowed size for a single imported
+     * file is always bounded.
+     *
+     * File size is specified in bytes. Default is 50 MB.
+     */
+    "importMaxFileSize": "${IMPORT_MAX_FILE_SIZE:52428800}", // 50 * 1024 * 1024
+  
+    /*
+     * From Etherpad 1.8.5 onwards, when Etherpad is in production mode commits from individual users are rate limited
+     *
+     * The default is to allow at most 10 changes per IP in a 1 second window.
+     * After that the change is rejected.
+     *
+     * See https://github.com/animir/node-rate-limiter-flexible/wiki/Overall-example#websocket-single-connection-prevent-flooding for more options
+     */
+    "commitRateLimiting": {
+      // duration of the rate limit window (seconds)
+      "duration": "${COMMIT_RATE_LIMIT_DURATION:1}",
+  
+      // maximum number of changes per IP to allow during the rate limit window
+      "points": "${COMMIT_RATE_LIMIT_POINTS:10}"
+    },
+  
+    /*
+     * Toolbar buttons configuration.
+     */
+    "toolbar": {
+      "left": [
+        ["bold", "italic", "underline", "strikethrough"],
+        ["orderedlist", "unorderedlist", "indent", "outdent"],
+        ["undo", "redo"]
+      ],
+      "right": [
+        ["importexport", "timeslider", "savedrevision"],
+        ["settings", "embed"],
+        ["showusers"]
+      ],
+      "timeslider": [
+        ["timeslider_export", "timeslider_settings", "timeslider_returnToPad"]
+      ]
+    },
+  
+    /*
+     * Expose Etherpad version in the web interface and in the Server http header.
+     *
+     * Do not enable on production machines.
+     */
+    "exposeVersion": "${EXPOSE_VERSION:false}",
+  
+    /*
+     * The log level we are using.
+     *
+     * Valid values: DEBUG, INFO, WARN, ERROR
+     */
+    "loglevel": "${LOGLEVEL:INFO}",
+  
+    /* Override any strings found in locale directories */
+    "customLocaleStrings": {},
+  
+    /* Disable Admin UI tests */
+    "enableAdminUITests": false,
+  
+    /*
+     * Enable/Disable case-insensitive pad names.
+     */
+    "lowerCasePadIds": "${LOWER_CASE_PAD_IDS:false}",
+  
+    "ep_search": {
+      "type": "solr",
+      "host": "localhost",
+      "port": "8983",
+      "core": "pad"
+    }
+  }
+  


### PR DESCRIPTION
The `indexed` field was stamped with `new Date()` at serialization time, so reindexing after a Solr volume wipe overwrote every pad's timestamp with the reindex time, breaking "Date modified" ordering. Both indexing paths now use the pad's head revision timestamp via `Pad.getLastEdit()`.

- Load pads with `padManager.getPad()` on startup reindexing (and unload afterwards) so serializers receive a real Pad instance
- Support async pad serializers
- Stamp `indexed` with `await pad.getLastEdit()` in the default Solr serializer

Verified with ep_weave's Solr volume migration E2E: `indexed` survives a volume wipe unchanged, and the old behavior fails the new assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)