### PR TITLE
Apply search index updates in pad event order

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,31 @@ async function initializePad(pad) {
   }
 }
 
+const indexTasks = new Map();
+
+/**
+ * Chain index tasks per pad so that search engine updates are applied in
+ * the order of the pad events. A single pad may emit multiple padUpdate
+ * events in quick succession (e.g., setHTML clears and then rewrites the
+ * pad); without ordering, an add for an older revision can overwrite the
+ * latest one.
+ *
+ * @param {string} id ID of the pad.
+ * @param {*} task Async function to be performed for the pad.
+ */
+function enqueueIndexTask(id, task) {
+  const prev = indexTasks.get(id) || Promise.resolve();
+  const next = prev.catch(() => undefined).then(task);
+  indexTasks.set(id, next);
+  const cleanup = () => {
+    if (indexTasks.get(id) === next) {
+      indexTasks.delete(id);
+    }
+  };
+  next.then(cleanup, cleanup);
+  return next;
+}
+
 /**
  * Remove the index for the pad.
  *
@@ -125,10 +150,7 @@ exports.registerRoute = (hookName, args, cb) => {
  */
 exports.padRemoved = (hookName, args, cb) => {
   const { pad } = args;
-  removeAsync(pad)
-      .then(() => {
-          ;
-      })
+  enqueueIndexTask(pad.id, () => removeAsync(pad))
       .catch((err) => {
           console.error(logPrefix, 'Error occurred', err.stack || err.message || String(err));
       });
@@ -140,10 +162,7 @@ exports.padRemoved = (hookName, args, cb) => {
  */
 exports.padChanged = (hookName, args, cb) => {
   const { pad } = args;
-  updateAsync(pad)
-      .then(() => {
-          ;
-      })
+  enqueueIndexTask(pad.id, () => updateAsync(pad))
       .catch((err) => {
           console.error(logPrefix, 'Error occurred', err.stack || err.message || String(err));
       });

--- a/tests/e2e/notebooks/02_Update_Ordering.ipynb
+++ b/tests/e2e/notebooks/02_Update_Ordering.ipynb
@@ -1,0 +1,211 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "etherpad_url = \"http://localhost:9001/\"\n",
+    "marker_base = f\"zq{datetime.now().strftime('%Y%m%d%H%M%S')}x\"\n",
+    "update_iterations = 3\n",
+    "large_body_chars = 2000000\n",
+    "default_result_path = None\n",
+    "close_on_fail = False\n",
+    "transition_timeout = 10000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "work_dir = tempfile.mkdtemp()\n",
+    "if default_result_path is None:\n",
+    "    default_result_path = work_dir\n",
+    "work_dir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m0",
+   "metadata": {},
+   "source": [
+    "# ep_search E2E Test - Update Ordering\n",
+    "\n",
+    "Test that rapid successive updates of a pad leave the search index at the\n",
+    "latest content. Importing an HTML file rewrites the pad as two immediate\n",
+    "revisions (clear, then insert), so the index updates for both revisions race;\n",
+    "the index must converge to the final revision."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import importlib\n",
+    "\n",
+    "import scripts.playwright\n",
+    "importlib.reload(scripts.playwright)\n",
+    "\n",
+    "from scripts.playwright import *\n",
+    "\n",
+    "await init_pw_context(close_on_fail=close_on_fail, last_path=default_result_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m1",
+   "metadata": {},
+   "source": [
+    "## Step 1: Create a pad and wait until it is indexed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "import time\n",
+    "\n",
+    "pad_id = f\"test-ordering-{int(time.time())}\"\n",
+    "\n",
+    "\n",
+    "async def wait_for_search_hit(page, query, timeout_ms):\n",
+    "    deadline = time.monotonic() + timeout_ms / 1000\n",
+    "    result = None\n",
+    "    while time.monotonic() < deadline:\n",
+    "        response = await page.request.get(f\"{etherpad_url}search?query={query}\")\n",
+    "        assert response.ok, response.status\n",
+    "        result = await response.json()\n",
+    "        if result[\"numFound\"] == 1:\n",
+    "            return result\n",
+    "        await asyncio.sleep(1)\n",
+    "    raise AssertionError(f\"Pad not found by query {query}: {result}\")\n",
+    "\n",
+    "\n",
+    "async def _step(page):\n",
+    "    await page.goto(f\"{etherpad_url}p/{pad_id}\")\n",
+    "\n",
+    "    await expect(page.locator('iframe[name=\"ace_outer\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    iframe_locator = page.frame_locator('iframe[name=\"ace_outer\"]').frame_locator('iframe[name=\"ace_inner\"]')\n",
+    "    editor = iframe_locator.locator('#innerdocbody')\n",
+    "    await expect(editor).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "    await editor.click()\n",
+    "    await editor.press_sequentially(f\"OrderingTest {marker_base}0000\")\n",
+    "\n",
+    "    await wait_for_search_hit(page, f\"{marker_base}0000\", transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m2",
+   "metadata": {},
+   "source": [
+    "## Step 2: Rewrite the pad with a large body, then immediately with a small one\n",
+    "\n",
+    "Each import rewrites the pad, and the index update for a large body takes\n",
+    "longer than the one for a small body that follows right after it. The index\n",
+    "updates must be applied in the pad event order; if the slow update for the\n",
+    "older revision lands last, the index keeps the older content and the search\n",
+    "never converges to the last marker."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filler = \"検索順序の検証のための長い本文です。\" * (large_body_chars // 18)\n",
+    "\n",
+    "async def import_html(page, body):\n",
+    "    response = await page.request.post(\n",
+    "        f\"{etherpad_url}p/{pad_id}/import\",\n",
+    "        multipart={\n",
+    "            \"file\": {\n",
+    "                \"name\": \"import.html\",\n",
+    "                \"mimeType\": \"text/html\",\n",
+    "                \"buffer\": f\"<html><body>{body}</body></html>\".encode(),\n",
+    "            },\n",
+    "        },\n",
+    "    )\n",
+    "    assert response.ok, (response.status, await response.text())\n",
+    "\n",
+    "\n",
+    "async def _step(page):\n",
+    "    for i in range(1, update_iterations + 1):\n",
+    "        large_marker = f\"{marker_base}{i:04d}L\"\n",
+    "        last_marker = f\"{marker_base}{i:04d}S\"\n",
+    "        await import_html(page, f\"<p>OrderingTest</p><p>{large_marker}</p><p>{filler}</p>\")\n",
+    "        await import_html(page, f\"<p>OrderingTest</p><p>{last_marker}</p>\")\n",
+    "        result = await wait_for_search_hit(page, last_marker, transition_timeout)\n",
+    "        print(i, last_marker, result[\"numFound\"])\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m3",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await finish_pw_context(screenshot=True, last_path=default_result_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm -rf {work_dir}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
The padChanged hook indexes fire-and-forget, so concurrent updates for the same pad can reach Solr out of order. Etherpad's setHTML emits two revisions (clear, then rewrite), and the add for the cleared revision can land after the final one, leaving an empty document (`title: ''`) in the index — observed in ep_weave PR NII-cloud-operation/ep_weave#53 backend CI, where `/t/<title>` then missed the pad. The async serializer introduced in #3 widened this pre-existing race enough to surface it.

- Chain index updates and removals per pad so they are applied in pad event order (independent pads still run concurrently)
- Add an E2E test that rewrites a pad with a large body and immediately with a small one — the slow index update for the older revision must not overwrite the newer one

Verified locally against the E2E stack: the new test fails on the unfixed code (search never converges to the last marker) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)